### PR TITLE
Improvements for types and parameter clauses

### DIFF
--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -23,43 +23,26 @@
 	<dict>
 		<key>attribute</key>
 		<dict>
-			<key>begin</key>
-			<string>(@)(?&lt;q&gt;`?)[\p{L}_][\p{L}_\p{N}\p{M}]*(\k&lt;q&gt;)</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>storage.modifier.attribute.swift</string>
-				</dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.attribute.swift</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.identifier.swift</string>
-				</dict>
-				<key>3</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.identifier.swift</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>(?!\G\()</string>
 			<key>name</key>
 			<string>meta.attribute.swift</string>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>\(</string>
+					<string>((@)available)(\()</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>0</key>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>storage.modifier.attribute.swift</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.attribute.swift</string>
+						</dict>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.arguments.begin.swift</string>
@@ -75,13 +58,204 @@
 							<string>punctuation.definition.arguments.end.swift</string>
 						</dict>
 					</dict>
-					<key>name</key>
-					<string>meta.arguments.attribute.swift</string>
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>$self</string>
+							<key>match</key>
+							<string>\*</string>
+							<key>name</key>
+							<string>keyword.other.platform.all.swift</string>
+						</dict>
+						<dict>
+							<key>match</key>
+							<string>\bunavailable\b</string>
+							<key>name</key>
+							<string>keyword.other.swift</string>
+						</dict>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>keyword.other.platform.os.swift</string>
+								</dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>constant.numeric.swift</string>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>\b((?:iOS|macOS|watchOS|tvOS)(?:ApplicationExtension)?)\b(?:\s+([0-9]+(?:\.[0-9]+)*\b))?</string>
+						</dict>
+						<dict>
+							<key>begin</key>
+							<string>\b(introduced|deprecated|obsoleted)\s*(:)\s*</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>keyword.other.swift</string>
+								</dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.separator.key-value.swift</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>(?!\G)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>match</key>
+									<string>\b[0-9]+(?:\.[0-9]+)*\b</string>
+									<key>name</key>
+									<string>constant.numeric.swift</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>begin</key>
+							<string>\b(message|renamed)\s*(:)\s*(?=")</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>keyword.other.swift</string>
+								</dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.separator.key-value.swift</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>(?!\G)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#literals</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>((@)objc)(\()</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>storage.modifier.attribute.swift</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.attribute.swift</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.arguments.begin.swift</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.arguments.end.swift</string>
+						</dict>
+					</dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>invalid.illegal.missing-colon-after-selector-piece.swift</string>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>\w*(?::(?:\w*:)*(\w*))?</string>
+							<key>name</key>
+							<string>entity.name.function.swift</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(@)(?&lt;q&gt;`?)[\p{L}_][\p{L}_0-9\p{Mn}]+(\k&lt;q&gt;)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>storage.modifier.attribute.swift</string>
+						</dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.attribute.swift</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.identifier.swift</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.identifier.swift</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>any other attribute</string>
+					<key>end</key>
+					<string>(?!\G\()</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>begin</key>
+							<string>\(</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.arguments.begin.swift</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>\)</string>
+							<key>endCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.arguments.end.swift</string>
+								</dict>
+							</dict>
+							<key>name</key>
+							<string>meta.arguments.attribute.swift</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#expressions</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>


### PR DESCRIPTION
``` swift
func foo(
    bar baz: Int,
    and this: inout [Key: Value : whoops] = { defer { fatalError() } return $0+2 }(/*no args*/),
    and that: String) {
    // body
}
```

<img width="707" alt="screen shot 2016-09-24 at 12 34 36 am" src="https://cloud.githubusercontent.com/assets/14237/18806894/aee529d0-81ee-11e6-8112-bf3b1eb95cc6.png">
