### PR TITLE
Match foo.init() as a call, not a declaration

### DIFF
--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -1493,7 +1493,7 @@
 				<key>function-initializer</key>
 				<dict>
 					<key>begin</key>
-					<string>\b(init[?!]?)\s*(?=\(|&lt;)</string>
+					<string>(?&lt;!\.)\b(init[?!]?)\s*(?=\(|&lt;)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
Fixes https://github.com/jtbandes/swift.tmbundle/pull/3

cc @patrickrgaffney

Can you think of any cases which this doesn't correctly fix?
